### PR TITLE
hotfix(deploy) : fix ssh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Deploy with rsync
         run: |
           ls -a
-          ssh ${{ secrets.SSH_HOST }} 'cd /home/$USER/tbd-develop; rm -rf frontend backend db'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} 'cd /home/$USER/tbd-develop; sudo rm -rf frontend backend db'
           rsync -auvPz ./ ${{ secrets.SSH_HOST }}:/home/${{ secrets.SSH_USER }}/tbd-develop/
           ssh ${{ secrets.SSH_HOST }} 'cd /home/$USER/tbd-develop/backend; touch .env.local; echo OPENAI_API_KEY=\"${{ secrets.OPENAI_API_KEY }}\" >> .env.local'
           ssh ${{ secrets.SSH_HOST }} 'cd /home/$USER/tbd-develop/backend; echo REACT_BASE_URL=\"tbd-develop.st.ie.u-ryukyu.ac.jp\" >> .env.local'


### PR DESCRIPTION
sudoコマンドをパスワードを入れなくても実行できるように編集した。
"secrets.SSH_USER"はsudoがパスワードなしでも実行できる